### PR TITLE
fix: elixir `:force_build` configuration and address checksum reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+---
+
+## [Unreleased]
+
+### Fixed
+
+- **Elixir bindings now respect the `:force_build` configuration.** Previously, setting `config :rustler_precompiled, :force_build, kreuzcrawl: true` in Elixir projects was ignored by the native loader. This made it impossible to bypass precompiled binary checksum failures by building from source as suggested in the error message. The loader now correctly checks `Application.compile_env/3`.

--- a/packages/elixir/lib/kreuzcrawl/native.ex
+++ b/packages/elixir/lib/kreuzcrawl/native.ex
@@ -9,7 +9,8 @@ defmodule Kreuzcrawl.Native do
       "https://github.com/kreuzberg-dev/kreuzcrawl/releases/download/v#{Mix.Project.config()[:version]}",
     version: Mix.Project.config()[:version],
     force_build:
-      System.get_env("KREUZCRAWL_BUILD") in ["1", "true"] or Mix.env() in [:test, :dev],
+      System.get_env("KREUZCRAWL_BUILD") in ["1", "true"] or Mix.env() in [:test, :dev] or
+        Application.compile_env(:rustler_precompiled, :force_build)[:kreuzcrawl],
     targets:
       ~w(aarch64-apple-darwin aarch64-unknown-linux-gnu x86_64-unknown-linux-gnu x86_64-pc-windows-gnu),
     nif_versions: ["2.16", "2.17"]


### PR DESCRIPTION
fixes #7  an issue where the `:force_build` configuration for `rustler_precompiled` was ignored by the Elixir bindings. This prevented users from building the NIF from source when precompiled binary checksums failed.

**changes**:
- Modified `lib/kreuzcrawl/native.ex` to include a check for `Application.compile_env(:rustler_precompiled, :force_build)[:kreuzcrawl]`.
- This allows the workaround suggested in the error message to actually work.

**verification**:
- Verified with a reproduction app that the configuration is now correctly picked up during compilation.
- Confirmed that version `0.1.1` checksums are currently valid, but this change provides a necessary safety valve for any future or past checksum discrepancies.

**related issues**:
- Fixes reported checksum issues by providing a working bypass mechanism.