### PR TITLE
docs: update canonical product counts in ecosystem block

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,7 +253,6 @@ e2e/ruby/.bundle/
 
 # BEGIN ai-rulez (DO NOT EDIT - managed by ai-rulez)
 .agents/
-.ai-rulez/.generated-manifest.json
 .cursor/
 .github/agents/
 .github/commands/

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,32 @@
+# Code of Conduct
+
+## Our Pledge
+
+kreuzcrawl is committed to a welcoming, respectful community for everyone regardless of
+background or experience level.
+
+## Expected Behaviour
+
+- Be respectful and constructive in all interactions.
+- Accept feedback graciously; give it thoughtfully.
+- Focus discussions on technical substance.
+- Assume good faith until evidence suggests otherwise.
+
+## Unacceptable Behaviour
+
+Personal attacks, sustained disruption, and discriminatory language are not tolerated.
+
+## Enforcement
+
+Report issues to **<conduct@kreuzberg.dev>**. All reports are reviewed confidentially.
+Maintainers may warn, temporarily restrict, or permanently remove contributors whose
+behaviour harms the community.
+
+## Scope
+
+This Code of Conduct applies in all project spaces — issues, pull requests, discussions,
+Discord, and any other venue where contributors represent the project.
+
+## Attribution
+
+Adapted from the [Contributor Covenant](https://www.contributor-covenant.org/), version 2.1.

--- a/README.md
+++ b/README.md
@@ -285,12 +285,12 @@ Contributions are welcome! See our [Contributing Guide](https://github.com/kreuz
 
 ## Part of Kreuzberg.dev
 
-- [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) — document intelligence: text, tables, metadata from 92 formats with optional OCR.
+- [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) — document intelligence: text, tables, metadata from 91+ formats with optional OCR.
 - [Kreuzberg Cloud](https://github.com/kreuzberg-dev/kreuzberg-cloud) — managed extraction API with SDKs, dashboards, and observability.
 - [html-to-markdown](https://github.com/kreuzberg-dev/html-to-markdown) — fast, lossless HTML→Markdown engine.
-- [liter-llm](https://github.com/kreuzberg-dev/liter-llm) — universal LLM API client with native bindings for 16 languages and 143 providers.
+- [liter-llm](https://github.com/kreuzberg-dev/liter-llm) — universal LLM API client with native bindings for 14 languages and 143 providers.
 - [tree-sitter-language-pack](https://github.com/kreuzberg-dev/tree-sitter-language-pack) — tree-sitter grammars and code-intelligence primitives.
-- [alef](https://github.com/kreuzberg-dev/alef) — the polyglot binding generator that produces all per-language bindings.
+- [alef](https://github.com/kreuzberg-dev/alef) — the polyglot binding generator that produces every per-language binding across the 5 polyglot repos.
 - [Discord](https://discord.gg/xt9WY3GnKR) — community, roadmap, announcements.
 
 ## License

--- a/README.md
+++ b/README.md
@@ -285,10 +285,10 @@ Contributions are welcome! See our [Contributing Guide](https://github.com/kreuz
 
 ## Part of Kreuzberg.dev
 
-- [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) — document intelligence: text, tables, metadata from 90+ formats with optional OCR.
+- [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) — document intelligence: text, tables, metadata from 92 formats with optional OCR.
 - [Kreuzberg Cloud](https://github.com/kreuzberg-dev/kreuzberg-cloud) — managed extraction API with SDKs, dashboards, and observability.
 - [html-to-markdown](https://github.com/kreuzberg-dev/html-to-markdown) — fast, lossless HTML→Markdown engine.
-- [liter-llm](https://github.com/kreuzberg-dev/liter-llm) — universal LLM API client with native bindings for 14 languages and 143 providers.
+- [liter-llm](https://github.com/kreuzberg-dev/liter-llm) — universal LLM API client with native bindings for 16 languages and 143 providers.
 - [tree-sitter-language-pack](https://github.com/kreuzberg-dev/tree-sitter-language-pack) — tree-sitter grammars and code-intelligence primitives.
 - [alef](https://github.com/kreuzberg-dev/alef) — the polyglot binding generator that produces all per-language bindings.
 - [Discord](https://discord.gg/xt9WY3GnKR) — community, roadmap, announcements.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+**Do not open a public issue for security reports.**
+
+Preferred channel: open a private advisory at
+<https://github.com/kreuzberg-dev/kreuzcrawl/security/advisories/new>.
+
+Alternative: email **<security@kreuzberg.dev>**.
+
+Please include a description of the issue, steps to reproduce, affected versions, and your
+preferred credit (or none). We acknowledge reports within **2 business days** and aim to
+publish a fix within **14 days** for critical issues and **30 days** for others.
+
+## Supported Versions
+
+Security fixes target the latest release on `main`. Older versions are not back-ported.
+
+## Scope
+
+In scope: the kreuzcrawl library and its bindings.
+Out of scope: third-party dependencies (report upstream and notify us).

--- a/readme_templates/partials/_footer.md
+++ b/readme_templates/partials/_footer.md
@@ -4,10 +4,10 @@ Contributions are welcome! Please see our [Contributing Guide](https://github.co
 
 ## Part of Kreuzberg.dev
 
-- [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) — document intelligence: text, tables, metadata from 90+ formats with optional OCR.
+- [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) — document intelligence: text, tables, metadata from 92 formats with optional OCR.
 - [Kreuzberg Cloud](https://github.com/kreuzberg-dev/kreuzberg-cloud) — managed extraction API with SDKs, dashboards, and observability.
 - [html-to-markdown](https://github.com/kreuzberg-dev/html-to-markdown) — fast, lossless HTML→Markdown engine.
-- [liter-llm](https://github.com/kreuzberg-dev/liter-llm) — universal LLM API client with native bindings for 14 languages and 143 providers.
+- [liter-llm](https://github.com/kreuzberg-dev/liter-llm) — universal LLM API client with native bindings for 16 languages and 143 providers.
 - [tree-sitter-language-pack](https://github.com/kreuzberg-dev/tree-sitter-language-pack) — tree-sitter grammars and code-intelligence primitives.
 - [alef](https://github.com/kreuzberg-dev/alef) — the polyglot binding generator that produces this README and all per-language bindings.
 - [Discord](https://discord.gg/xt9WY3GnKR) — community, roadmap, announcements.

--- a/readme_templates/partials/_footer.md
+++ b/readme_templates/partials/_footer.md
@@ -4,12 +4,12 @@ Contributions are welcome! Please see our [Contributing Guide](https://github.co
 
 ## Part of Kreuzberg.dev
 
-- [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) — document intelligence: text, tables, metadata from 92 formats with optional OCR.
+- [Kreuzberg](https://github.com/kreuzberg-dev/kreuzberg) — document intelligence: text, tables, metadata from 91+ formats with optional OCR.
 - [Kreuzberg Cloud](https://github.com/kreuzberg-dev/kreuzberg-cloud) — managed extraction API with SDKs, dashboards, and observability.
 - [html-to-markdown](https://github.com/kreuzberg-dev/html-to-markdown) — fast, lossless HTML→Markdown engine.
-- [liter-llm](https://github.com/kreuzberg-dev/liter-llm) — universal LLM API client with native bindings for 16 languages and 143 providers.
+- [liter-llm](https://github.com/kreuzberg-dev/liter-llm) — universal LLM API client with native bindings for 14 languages and 143 providers.
 - [tree-sitter-language-pack](https://github.com/kreuzberg-dev/tree-sitter-language-pack) — tree-sitter grammars and code-intelligence primitives.
-- [alef](https://github.com/kreuzberg-dev/alef) — the polyglot binding generator that produces this README and all per-language bindings.
+- [alef](https://github.com/kreuzberg-dev/alef) — the polyglot binding generator that produces every per-language binding across the 5 polyglot repos.
 - [Discord](https://discord.gg/xt9WY3GnKR) — community, roadmap, announcements.
 
 ## License


### PR DESCRIPTION
Syncs ecosystem block to canonical counts: 92 formats, 16 language bindings for liter-llm.