### PR TITLE
ci: optimize sccache and fix go cache path in E2E workflow

### DIFF
--- a/.github/workflows/ci-e2e.yaml
+++ b/.github/workflows/ci-e2e.yaml
@@ -169,6 +169,7 @@ jobs:
         uses: xberg-io/actions/setup-rust@v1
         with:
           cache-key-prefix: e2e-${{ matrix.lang }}
+          use-sccache: ${{ matrix.lang == 'rust' || matrix.lang == 'wasm' }}
 
       - name: Download FFI artifacts
         uses: actions/download-artifact@v8
@@ -249,6 +250,8 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version: ${{ matrix.go-version }}
+          cache: true
+          cache-dependency-path: go.work.sum
 
       - name: Setup Ruby
         if: matrix.ruby-version


### PR DESCRIPTION
## Fix CI caching: sccache scope & Go dependency path

Fixes two caching issues in `ci-e2e.yaml` identified in CI logs:

1. **Restrict `sccache` to `rust`/`wasm` matrix jobs**: 11/13 E2E jobs consume pre-built FFI binaries and don't compile Rust. Enabling sccache unconditionally generated ~1,000 cache write errors per run on non-compiling legs.
2. **Fix Go cache key** : `actions/setup-go` searched the repo root for `go.mod` instead of the workspace lockfile. Explicitly setting `cache-dependency-path: go.work.sum` fixes cache restore and produces a stable key.

### Impact
- Eliminates sccache write error noise on non-Rust E2E jobs
- Fixes Go module cache restore